### PR TITLE
Fix off-by-one when picking flag symbol

### DIFF
--- a/scrollbar.kak
+++ b/scrollbar.kak
@@ -66,7 +66,7 @@ define-command update-scrollbar -hidden -override %{
                 for (i = view_top; i <= view_bottom; i++) {
                     # Choose a flag symbol based on the number of selections
                     if (selections[i] > length(sel_chars)) {
-                        count = length(sel_chars)
+                        count = length(sel_chars) - 1
                     } else {
                         count = selections[i]
                     }


### PR DESCRIPTION
Before if you had too many selections, there would simply be no symbol shown.